### PR TITLE
Support additional params in authorize_url()

### DIFF
--- a/lib/Net/Google/DataAPI/Auth/OAuth2.pm
+++ b/lib/Net/Google/DataAPI/Auth/OAuth2.pm
@@ -40,7 +40,8 @@ has access_token => (is => 'rw', isa => 'Net::Google::DataAPI::Types::OAuth2::Ac
 sub authorize_url {
     my $self = shift;
     return $self->oauth2_webserver->authorize_url(
-        scope => join(' ', $self->scope)
+        scope => join(' ', $self->scope),
+        @_
     );
 }
 


### PR DESCRIPTION
https://developers.google.com/accounts/docs/OAuth2WebServer

``` perl
$yt->authorize_url(
  access_type => 'offline',
  approval_prompt => 'force',
)
```
